### PR TITLE
Update pair.py

### DIFF
--- a/docker-install.md
+++ b/docker-install.md
@@ -1,0 +1,80 @@
+docker.server.config.yaml 
+log:
+  level: "INFO"
+
+host: "0.0.0.0"
+port: 10000
+data: "server_data.txt"
+result: "server_result.txt"
+
+
+docker.client.config.yaml 
+log:
+  level: "INFO"
+
+host: "0.0.0.0"
+port: 10000
+data: "client_data.txt"
+result: "client_result.txt"
+
+
+安装包：
+psi.tar
+
+docker镜像：
+suning_psi.tar
+
+
+安装步骤：
+1、解压缩tar xvf psi.tar -C dockerpsi
+2、cd dockerpsi/psi/python-psi
+3、修改psi\pair\socket\pair.py
+    def recv(self) -> bytes:
+        length = bytes_to_int(self._recv(4))
+        data = self._recv(length)
+        return data
+
+    def _recv(self, count: int) -> bytes:
+        buffer = bytearray(count)
+        view = memoryview(buffer)
+
+        while count > 0:
+            n = self._sock.recv_into(view, count)
+            view = view[n:]
+            count -= n
+
+        return bytes(buffer)
+		
+3、修改Dockerfile文件：
+FROM python:3.8-buster as builder
+
+WORKDIR /app
+
+COPY psi /app/psi
+COPY setup.py /app/setup.py
+
+RUN pip wheel -w whls . -i https://pypi.tuna.tsinghua.edu.cn/simple
+
+FROM python:3.8-slim-buster
+
+WORKDIR /app
+
+COPY --from=builder /app/whls /app/whls
+
+RUN pip install --no-cache-dir whls/*.whl &&  rm -rf whls
+
+ENTRYPOINT [ "psi_run" ]
+4、docker build -f Dockerfile -t suning_psi:1.0.0 .
+生成镜像文件suning_psi:1.0.0
+5、docker save -o suning_psi.tar  suning_psi:1.0.0
+镜像保存到：suning_psi.tar
+并同步到对端scp suning_psi.tar fate@对端IP:/data
+6、在对端执行docker load < suning_psi.tar，加载镜像
+
+7、执行命令
+docker run -p 10000:10000 -e PSI_CONFIG=config/docker.server.config.yaml -v /data/psi/python-psi/config:/app/config -v  /data/psi/python-psi/server_data.txt:/app/server_data.txt -t -i suning_psi:1.0.0 server 10.237.73.82:10000
+docker run -p 10000:10000 -e PSI_CONFIG=config/docker.client.config.yaml -v /data/python-psi/config:/app/config -v /data/python-psi/client_data.txt:/app/client_data.txt -t -i suning_psi:1.0.0 client 10.237.73.14:10000
+
+8、docker和宿主机之间复制数据
+docker cp  /usr/local/python3/lib/python3.8/site-packages/psi/pair/socket/pair.py cff880d0f153:/usr/local/lib/python3.8/site-packages/psi/pair/socket/pair.py
+docker cp  c9e39bf6a9db:/usr/local/lib/python3.8/site-packages/psi/pair/socket/pair.py /data

--- a/docker-install.md
+++ b/docker-install.md
@@ -21,10 +21,6 @@ result: "client_result.txt"
 安装包：
 psi.tar
 
-docker镜像：
-suning_psi.tar
-
-
 安装步骤：
 1、解压缩tar xvf psi.tar -C dockerpsi
 2、cd dockerpsi/psi/python-psi
@@ -64,16 +60,16 @@ COPY --from=builder /app/whls /app/whls
 RUN pip install --no-cache-dir whls/*.whl &&  rm -rf whls
 
 ENTRYPOINT [ "psi_run" ]
-4、docker build -f Dockerfile -t suning_psi:1.0.0 .
+4、docker build -f Dockerfile -t delta_psi:1.0.0 .
 生成镜像文件suning_psi:1.0.0
-5、docker save -o suning_psi.tar  suning_psi:1.0.0
-镜像保存到：suning_psi.tar
-并同步到对端scp suning_psi.tar fate@对端IP:/data
-6、在对端执行docker load < suning_psi.tar，加载镜像
+5、docker save -o delta_psi.tar  delta_psi:1.0.0
+镜像保存到：delta_psi.tar
+并同步到对端scp delta_psi.tar fate@对端IP:/data
+6、在对端执行docker load < delta_psi.tar，加载镜像
 
 7、执行命令
-docker run -p 10000:10000 -e PSI_CONFIG=config/docker.server.config.yaml -v /data/psi/python-psi/config:/app/config -v  /data/psi/python-psi/server_data.txt:/app/server_data.txt -t -i suning_psi:1.0.0 server 10.237.73.82:10000
-docker run -p 10000:10000 -e PSI_CONFIG=config/docker.client.config.yaml -v /data/python-psi/config:/app/config -v /data/python-psi/client_data.txt:/app/client_data.txt -t -i suning_psi:1.0.0 client 10.237.73.14:10000
+docker run -p 10000:10000 -e PSI_CONFIG=config/docker.server.config.yaml -v /data/psi/python-psi/config:/app/config -v  /data/psi/python-psi/server_data.txt:/app/server_data.txt -t -i delta_psi:1.0.0 server 10.237.73.82:10000
+docker run -p 10000:10000 -e PSI_CONFIG=config/docker.client.config.yaml -v /data/python-psi/config:/app/config -v /data/python-psi/client_data.txt:/app/client_data.txt -t -i delta_psi:1.0.0 client 10.237.73.14:10000
 
 8、docker和宿主机之间复制数据
 docker cp  /usr/local/python3/lib/python3.8/site-packages/psi/pair/socket/pair.py cff880d0f153:/usr/local/lib/python3.8/site-packages/psi/pair/socket/pair.py

--- a/docker-install.md
+++ b/docker-install.md
@@ -1,76 +1,76 @@
-docker.server.config.yaml 
-log:
-  level: "INFO"
+        docker.server.config.yaml 
+        log:
+          level: "INFO"
 
-host: "0.0.0.0"
-port: 10000
-data: "server_data.txt"
-result: "server_result.txt"
-
-
-docker.client.config.yaml 
-log:
-  level: "INFO"
-
-host: "0.0.0.0"
-port: 10000
-data: "client_data.txt"
-result: "client_result.txt"
+        host: "0.0.0.0"
+        port: 10000
+        data: "server_data.txt"
+        result: "server_result.txt"
 
 
-安装包：
-psi.tar
+        docker.client.config.yaml 
+        log:
+          level: "INFO"
 
-安装步骤：
-1、解压缩tar xvf psi.tar -C dockerpsi
-2、cd dockerpsi/psi/python-psi
-3、修改psi\pair\socket\pair.py
-    def recv(self) -> bytes:
-        length = bytes_to_int(self._recv(4))
-        data = self._recv(length)
-        return data
+        host: "0.0.0.0"
+        port: 10000
+        data: "client_data.txt"
+        result: "client_result.txt"
 
-    def _recv(self, count: int) -> bytes:
-        buffer = bytearray(count)
-        view = memoryview(buffer)
 
-        while count > 0:
-            n = self._sock.recv_into(view, count)
-            view = view[n:]
-            count -= n
+        安装包：
+        psi.tar
 
-        return bytes(buffer)
-		
-3、修改Dockerfile文件：
-FROM python:3.8-buster as builder
+        安装步骤：
+        1、解压缩tar xvf psi.tar -C dockerpsi
+        2、cd dockerpsi/psi/python-psi
+        3、修改psi\pair\socket\pair.py
+            def recv(self) -> bytes:
+                length = bytes_to_int(self._recv(4))
+                data = self._recv(length)
+                return data
 
-WORKDIR /app
+            def _recv(self, count: int) -> bytes:
+                buffer = bytearray(count)
+                view = memoryview(buffer)
 
-COPY psi /app/psi
-COPY setup.py /app/setup.py
+                while count > 0:
+                    n = self._sock.recv_into(view, count)
+                    view = view[n:]
+                    count -= n
 
-RUN pip wheel -w whls . -i https://pypi.tuna.tsinghua.edu.cn/simple
+                return bytes(buffer)
 
-FROM python:3.8-slim-buster
+        4、修改Dockerfile文件：
+        FROM python:3.8-buster as builder
 
-WORKDIR /app
+        WORKDIR /app
 
-COPY --from=builder /app/whls /app/whls
+        COPY psi /app/psi
+        COPY setup.py /app/setup.py
 
-RUN pip install --no-cache-dir whls/*.whl &&  rm -rf whls
+        RUN pip wheel -w whls . -i https://pypi.tuna.tsinghua.edu.cn/simple
 
-ENTRYPOINT [ "psi_run" ]
-4、docker build -f Dockerfile -t delta_psi:1.0.0 .
-生成镜像文件suning_psi:1.0.0
-5、docker save -o delta_psi.tar  delta_psi:1.0.0
-镜像保存到：delta_psi.tar
-并同步到对端scp delta_psi.tar fate@对端IP:/data
-6、在对端执行docker load < delta_psi.tar，加载镜像
+        FROM python:3.8-slim-buster
 
-7、执行命令
-docker run -p 10000:10000 -e PSI_CONFIG=config/docker.server.config.yaml -v /data/psi/python-psi/config:/app/config -v  /data/psi/python-psi/server_data.txt:/app/server_data.txt -t -i delta_psi:1.0.0 server 10.237.73.82:10000
-docker run -p 10000:10000 -e PSI_CONFIG=config/docker.client.config.yaml -v /data/python-psi/config:/app/config -v /data/python-psi/client_data.txt:/app/client_data.txt -t -i delta_psi:1.0.0 client 10.237.73.14:10000
+        WORKDIR /app
 
-8、docker和宿主机之间复制数据
-docker cp  /usr/local/python3/lib/python3.8/site-packages/psi/pair/socket/pair.py cff880d0f153:/usr/local/lib/python3.8/site-packages/psi/pair/socket/pair.py
-docker cp  c9e39bf6a9db:/usr/local/lib/python3.8/site-packages/psi/pair/socket/pair.py /data
+        COPY --from=builder /app/whls /app/whls
+
+        RUN pip install --no-cache-dir whls/*.whl &&  rm -rf whls
+
+        ENTRYPOINT [ "psi_run" ]
+        5、docker build -f Dockerfile -t delta_psi:1.0.0 .
+        生成镜像文件suning_psi:1.0.0
+        6、docker save -o delta_psi.tar  delta_psi:1.0.0
+        镜像保存到：delta_psi.tar
+        并同步到对端scp delta_psi.tar fate@对端IP:/data
+        7、在对端执行docker load < delta_psi.tar，加载镜像
+
+        8、执行命令
+        docker run -p 10000:10000 -e PSI_CONFIG=config/docker.server.config.yaml -v /data/psi/python-psi/config:/app/config -v  /data/psi/python-psi/server_data.txt:/app/server_data.txt -t -i delta_psi:1.0.0 server 10.237.73.82:10000
+        docker run -p 10000:10000 -e PSI_CONFIG=config/docker.client.config.yaml -v /data/python-psi/config:/app/config -v /data/python-psi/client_data.txt:/app/client_data.txt -t -i delta_psi:1.0.0 client 10.237.73.14:10000
+
+        9、docker和宿主机之间复制数据
+        docker cp  /usr/local/python3/lib/python3.8/site-packages/psi/pair/socket/pair.py cff880d0f153:/usr/local/lib/python3.8/site-packages/psi/pair/socket/pair.py
+        docker cp  c9e39bf6a9db:/usr/local/lib/python3.8/site-packages/psi/pair/socket/pair.py /data

--- a/psi/pair/socket/pair.py
+++ b/psi/pair/socket/pair.py
@@ -120,7 +120,7 @@ class SocketPair(Pair):
         view = memoryview(buffer)
 
         while count > 0:
-            n = self._sock.recv_into(buffer)
+            n = self._sock.recv_into(view, count)
             view = view[n:]
             count -= n
 


### PR DESCRIPTION
一、问题修改点：
n = self._sock.recv_into(buffer)  修改为：n = self._sock.recv_into(view, count)
二、修改理由有两点：
1、接收信息应该通过view进行接收，解释理由：
下面代码可以在python在线编辑器运行一下，通过看执行结果就明白了为什么使用view对象接收消息了。
---------begin----------------------------------
buffer = bytearray(10)
view = memoryview(buffer)
print(buffer)  ##bytearray(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')

view[:1] = b'a'
print(buffer)  ##bytearray(b'a\x00\x00\x00\x00\x00\x00\x00\x00\x00')
view=view[1:]

view[:2] = b'bb'
print(buffer) ##bytearray(b'abb\x00\x00\x00\x00\x00\x00\x00')
view=view[2:]

view[:3] = b'cde'
print(buffer) ##bytearray(b'abbcde\x00\x00\x00\x00')
view=view[3:]

view[:1] = b'f'
print(buffer) ##bytearray(b'abbcdef\x00\x00\x00')
---------end----------------------------------
2、接收缓冲区的大小设置为剩余消息数据的大小，防止出现粘包问题
进而引起类似问题：AssertionError: base OT message length should be all the same, but the round 127 is not